### PR TITLE
Centralize env loading

### DIFF
--- a/rag_chatbot/main.py
+++ b/rag_chatbot/main.py
@@ -1,13 +1,12 @@
-import os
-from dotenv import load_dotenv
 from src.document_loader import load_documents
 from src.text_splitter import split_documents
 from src.vector_store import create_vector_store
 from src.rag_pipeline import initialize_rag_components, create_rag_graph
+from src.config import load_env, get_google_api_key
 
 def main():
-    # Carrega as variáveis de ambiente do arquivo .env
-    load_dotenv(dotenv_path='rag_chatbot/.env')
+    # Carrega as variáveis de ambiente apenas uma vez
+    load_env()
 
     print("Iniciando o processo de indexação de documentos...")
 
@@ -32,9 +31,7 @@ def main():
     # 3. Criar e popular o vector store (opcional para este teste, mas importante para o RAG)
     print("Criando e populando o vector store (isso pode levar um tempo e requer GOOGLE_API_KEY)...")
     try:
-        google_api_key = os.getenv("GOOGLE_API_KEY")
-        if not google_api_key:
-            raise ValueError("GOOGLE_API_KEY não está configurada no .env")
+        google_api_key = get_google_api_key()
 
         vector_store = create_vector_store(chunks) # create_vector_store já carrega a chave do ambiente
         print(f"Vector store populado com {vector_store._collection.count()} chunks.")

--- a/rag_chatbot/src/config.py
+++ b/rag_chatbot/src/config.py
@@ -1,0 +1,22 @@
+import os
+from functools import lru_cache
+from dotenv import load_dotenv
+
+@lru_cache(maxsize=1)
+def load_env(dotenv_path: str = 'rag_chatbot/.env') -> None:
+    """Load environment variables from a .env file once."""
+    load_dotenv(dotenv_path=dotenv_path)
+
+
+def get_env_var(key: str, default: str | None = None) -> str:
+    """Get an environment variable value ensuring .env is loaded."""
+    load_env()
+    value = os.getenv(key, default)
+    if value is None:
+        raise ValueError(f"Vari\u00e1vel de ambiente {key} n\u00e3o encontrada.")
+    return value
+
+
+def get_google_api_key() -> str:
+    """Return the Google API key from the environment."""
+    return get_env_var('GOOGLE_API_KEY')

--- a/rag_chatbot/src/llm_config.py
+++ b/rag_chatbot/src/llm_config.py
@@ -1,16 +1,16 @@
-import os
-from dotenv import load_dotenv
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-# Carrega as variáveis de ambiente do arquivo .env
-load_dotenv(dotenv_path='rag_chatbot/.env')
+from .config import get_google_api_key, load_env
+
+# Garante que as variáveis estejam carregadas apenas uma vez
+load_env()
 
 def get_chat_model(model_name: str = "gemini-1.5-pro", temperature: float = 0.7, api_key: str = None):
     """
     Configura e retorna o modelo de chat do Google Gemini.
     """
     if api_key is None:
-        api_key = os.getenv("GOOGLE_API_KEY")
+        api_key = get_google_api_key()
     
     if not api_key:
         raise ValueError("A variável de ambiente GOOGLE_API_KEY não está configurada ou não foi fornecida.")

--- a/rag_chatbot/src/streamlit_app.py
+++ b/rag_chatbot/src/streamlit_app.py
@@ -1,7 +1,8 @@
 import streamlit as st
 import os
 import sys
-from dotenv import load_dotenv
+
+from .config import load_env
 
 # Adicionar o diretório pai (rag_chatbot) ao sys.path para importações relativas
 # Isso é necessário quando o script é executado de dentro de um subdiretório (src)
@@ -11,8 +12,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from src.rag_pipeline import initialize_rag_components, create_rag_graph, GraphState
 from src.advanced_features import stream_rag_response # Importar a função de streaming
 
-# Carrega as variáveis de ambiente do arquivo .env
-load_dotenv(dotenv_path='rag_chatbot/.env')
+# Carrega as variáveis de ambiente apenas uma vez
+load_env()
 
 # --- Configuração da Página Streamlit ---
 st.set_page_config(page_title="RAG Chatbot with LangChain", layout="wide")

--- a/rag_chatbot/src/vector_store.py
+++ b/rag_chatbot/src/vector_store.py
@@ -1,18 +1,17 @@
-import os
-from dotenv import load_dotenv
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langchain_community.vectorstores import Chroma
 from langchain_core.documents import Document
 
-# Carrega as variáveis de ambiente do arquivo .env
-load_dotenv(dotenv_path='rag_chatbot/.env')
+from .config import get_google_api_key, load_env
+# Garante que as variáveis estejam carregadas apenas uma vez
+load_env()
 
 def get_embeddings_model(api_key: str = None):
     """
     Configura e retorna o modelo de embeddings do Google Generative AI.
     """
     if api_key is None:
-        api_key = os.getenv("GOOGLE_API_KEY")
+        api_key = get_google_api_key()
 
     if not api_key:
         raise ValueError("A variável de ambiente GOOGLE_API_KEY não está configurada ou não foi fornecida.")


### PR DESCRIPTION
## Summary
- add `config.py` module to load `.env` once and expose helper getters
- refactor modules to import from new config and drop direct `load_dotenv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c204076c883239e7f47117c6bb0f4