### PR TITLE
Add reusable analysis prompt

### DIFF
--- a/rag_chatbot/src/advanced_features.py
+++ b/rag_chatbot/src/advanced_features.py
@@ -4,6 +4,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.runnables import Runnable, RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate # Necessário para o prompt de análise
+from rag_chatbot.src.prompt_template import get_analysis_prompt
 
 # Importar componentes do pipeline RAG (apenas o necessário, LLM e prompt serão passados)
 from src.rag_pipeline import initialize_rag_components, create_rag_graph, GraphState
@@ -20,11 +21,8 @@ def stream_rag_response(question: str, rag_app: Runnable, llm_model: any, rag_pr
     # Obter o LLM estruturado para análise de consulta
     structured_llm = llm_model.with_structured_output(GraphState.__annotations__['query']) # Reutiliza o schema Search do GraphState
 
-    # Prompt para análise da consulta (duplicado de rag_pipeline para evitar dependência circular)
-    analysis_prompt = ChatPromptTemplate.from_messages([
-        ("system", "Analise a pergunta do usuário e determine a consulta principal e a seção relevante do documento (beginning, middle, end)."),
-        ("human", "Pergunta: {question}\n\nRetorne a consulta e a seção no formato JSON com os campos 'query' e 'section'.")
-    ])
+    # Prompt para análise da consulta
+    analysis_prompt = get_analysis_prompt()
     analysis_chain = analysis_prompt | structured_llm
     
     # Analisar a consulta

--- a/rag_chatbot/src/prompt_template.py
+++ b/rag_chatbot/src/prompt_template.py
@@ -27,8 +27,22 @@ Pergunta: {question}
     # Para simplificar e garantir que as instruções sejam seguidas,
     # vamos criar um novo template com as instruções explícitas.
     custom_rag_prompt = ChatPromptTemplate.from_template(custom_template)
-    
+
     return custom_rag_prompt
+
+
+def get_analysis_prompt() -> ChatPromptTemplate:
+    """Retorna o prompt utilizado para analisar a consulta do usuário."""
+    return ChatPromptTemplate.from_messages([
+        (
+            "system",
+            "Analise a pergunta do usuário e determine a consulta principal e a seção relevante do documento (beginning, middle, end).",
+        ),
+        (
+            "human",
+            "Pergunta: {question}\n\nRetorne a consulta e a seção no formato JSON com os campos 'query' e 'section'.",
+        ),
+    ])
 
 if __name__ == "__main__":
     prompt = get_rag_prompt_template()

--- a/rag_chatbot/src/rag_pipeline.py
+++ b/rag_chatbot/src/rag_pipeline.py
@@ -12,7 +12,6 @@ from typing import List, TypedDict, Literal
 from langchain_core.documents import Document
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate # Adicionar esta importação
 from langgraph.graph import StateGraph, END
 
 # Importar funções dos módulos criados
@@ -20,7 +19,7 @@ from rag_chatbot.src.document_loader import load_documents
 from rag_chatbot.src.text_splitter import split_documents
 from rag_chatbot.src.vector_store import create_vector_store, get_embeddings_model
 from rag_chatbot.src.llm_config import get_chat_model
-from rag_chatbot.src.prompt_template import get_rag_prompt_template
+from rag_chatbot.src.prompt_template import get_rag_prompt_template, get_analysis_prompt
 
 # 1. Definir o schema Search
 class Search(TypedDict):
@@ -86,10 +85,7 @@ def analyze_query(state: GraphState, structured_llm):
     question = state["question"]
     
     # Prompt para análise da consulta
-    analysis_prompt = ChatPromptTemplate.from_messages([
-        ("system", "Analise a pergunta do usuário e determine a consulta principal e a seção relevante do documento (beginning, middle, end)."),
-        ("human", "Pergunta: {question}\n\nRetorne a consulta e a seção no formato JSON com os campos 'query' e 'section'.")
-    ])
+    analysis_prompt = get_analysis_prompt()
 
     # Cadeia de análise
     analysis_chain = analysis_prompt | structured_llm


### PR DESCRIPTION
## Summary
- define `get_analysis_prompt` helper in `prompt_template.py`
- use the helper in `rag_pipeline` and `advanced_features`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c20472a4c832380ab8e27f9a2e6f3