### PR TITLE
Add persistence option to vector store

### DIFF
--- a/rag_chatbot/main.py
+++ b/rag_chatbot/main.py
@@ -36,7 +36,8 @@ def main():
         if not google_api_key:
             raise ValueError("GOOGLE_API_KEY não está configurada no .env")
 
-        vector_store = create_vector_store(chunks) # create_vector_store já carrega a chave do ambiente
+        persist_directory = os.getenv("CHROMA_PERSIST_DIRECTORY")
+        vector_store = create_vector_store(chunks, persist_directory=persist_directory)
         print(f"Vector store populado com {vector_store._collection.count()} chunks.")
         print("\nSistema de indexação de documentos configurado e testado com sucesso.")
     except Exception as e:

--- a/rag_chatbot/src/rag_pipeline.py
+++ b/rag_chatbot/src/rag_pipeline.py
@@ -60,7 +60,8 @@ def initialize_rag_components():
     # Carregar e dividir documentos para o vector store
     documents = load_documents()
     chunks = split_documents(documents)
-    vector_store = create_vector_store(chunks)
+    persist_directory = os.getenv("CHROMA_PERSIST_DIRECTORY")
+    vector_store = create_vector_store(chunks, persist_directory=persist_directory)
     
     # Configurar LLM e Prompt
     llm = get_chat_model()

--- a/rag_chatbot/src/vector_store.py
+++ b/rag_chatbot/src/vector_store.py
@@ -21,17 +21,20 @@ def get_embeddings_model(api_key: str = None):
     # O modelo de embeddings do Google é geralmente "models/embedding-001".
     return GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=api_key)
 
-def create_vector_store(documents: list[Document]):
+def create_vector_store(documents: list[Document], persist_directory: str | None = None):
     """
-    Cria e popula um vector store em memória com os documentos fornecidos.
+    Cria e popula um vector store com os documentos fornecidos.
+    Se ``persist_directory`` for informado, o Chroma será persistido nesse caminho.
     """
     embeddings = get_embeddings_model()
     # Usando Chroma como um exemplo de vector store em memória
     vector_store = Chroma.from_documents(
         documents=documents,
         embedding=embeddings,
-        # persist_directory="./chroma_db" # Para persistir em disco, se necessário
+        persist_directory=persist_directory,
     )
+    if persist_directory:
+        vector_store.persist()
     return vector_store
 
 def add_documents_to_vector_store(vector_store: Chroma, documents: list[Document]):


### PR DESCRIPTION
## Summary
- allow persisting Chroma vector store
- load persistence path from `CHROMA_PERSIST_DIRECTORY` env var in RAG components and main script

## Testing
- `python -m py_compile rag_chatbot/src/*.py rag_chatbot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c20557a388323950094c6182716eb