### PR TITLE
Add basic pytest suite with stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ChatBot-LangChain-REG
+
+Este repositório contém um exemplo simples de integração entre LangChain e recursos de RAG.
+
+## Testes
+
+Os testes unitários estão localizados no diretório `tests/` e usam `pytest`.
+Para executá-los, no diretório raiz do projeto, rode:
+
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import types
+import pytest
+
+@pytest.fixture(autouse=True)
+def stub_libraries(monkeypatch):
+    """Provide minimal stubs for external libraries used by the project."""
+    # bs4
+    bs4_module = types.ModuleType("bs4")
+    bs4_module.BeautifulSoup = lambda *args, **kwargs: None
+    bs4_module.SoupStrainer = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "bs4", bs4_module)
+
+    # langchain_community.document_loaders
+    loaders_module = types.ModuleType("langchain_community.document_loaders")
+    class DummyLoader:
+        def __init__(self, *args, **kwargs):
+            pass
+        def load(self):
+            return [types.SimpleNamespace(page_content="stub document", metadata={})]
+    loaders_module.WebBaseLoader = DummyLoader
+    monkeypatch.setitem(sys.modules, "langchain_community.document_loaders", loaders_module)
+
+    # langchain_text_splitters
+    splitters_module = types.ModuleType("langchain_text_splitters")
+    class DummySplitter:
+        def __init__(self, *args, **kwargs):
+            pass
+        def split_documents(self, docs):
+            return docs
+    splitters_module.RecursiveCharacterTextSplitter = DummySplitter
+    monkeypatch.setitem(sys.modules, "langchain_text_splitters", splitters_module)
+
+    # langchain_core.documents
+    core_docs_module = types.ModuleType("langchain_core.documents")
+    class DummyDocument:
+        def __init__(self, page_content, metadata=None):
+            self.page_content = page_content
+            self.metadata = metadata or {}
+    core_docs_module.Document = DummyDocument
+    monkeypatch.setitem(sys.modules, "langchain_core.documents", core_docs_module)
+
+    # dotenv
+    dotenv_module = types.ModuleType("dotenv")
+    def load_dotenv(*args, **kwargs):
+        return True
+    dotenv_module.load_dotenv = load_dotenv
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_module)
+
+    # langchain_google_genai
+    genai_module = types.ModuleType("langchain_google_genai")
+    class DummyEmbeddings:
+        def __init__(self, *args, **kwargs):
+            pass
+    genai_module.GoogleGenerativeAIEmbeddings = DummyEmbeddings
+    monkeypatch.setitem(sys.modules, "langchain_google_genai", genai_module)
+
+    # langchain_community.vectorstores
+    vector_module = types.ModuleType("langchain_community.vectorstores")
+    class DummyChroma:
+        def __init__(self):
+            self.documents = []
+        @classmethod
+        def from_documents(cls, documents, embedding=None, **kwargs):
+            obj = cls()
+            obj.documents = list(documents)
+            obj.embedding = embedding
+            return obj
+        def as_retriever(self, **kwargs):
+            return self
+        def invoke(self, query):
+            return self.documents
+    vector_module.Chroma = DummyChroma
+    monkeypatch.setitem(sys.modules, "langchain_community.vectorstores", vector_module)
+
+    # Ensure GOOGLE_API_KEY exists so get_embeddings_model doesn't fail
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,28 @@
+import importlib
+from types import SimpleNamespace
+
+
+def test_load_documents():
+    module = importlib.import_module('rag_chatbot.src.document_loader')
+    docs = module.load_documents('http://example.com')
+    assert len(docs) == 1
+    assert docs[0].page_content == 'stub document'
+
+
+def test_split_documents():
+    text_module = importlib.import_module('rag_chatbot.src.text_splitter')
+    Document = importlib.import_module('langchain_core.documents').Document
+    docs = [Document(page_content=f'doc {i}') for i in range(3)]
+    chunks = text_module.split_documents(docs)
+    assert len(chunks) == 3
+    sections = {c.metadata.get('section') for c in chunks}
+    assert sections <= {'beginning', 'middle', 'end'}
+
+
+def test_create_vector_store():
+    vector_module = importlib.import_module('rag_chatbot.src.vector_store')
+    Document = importlib.import_module('langchain_core.documents').Document
+    docs = [Document(page_content='content')]
+    store = vector_module.create_vector_store(docs)
+    assert isinstance(store, vector_module.Chroma)
+    assert store.documents == docs


### PR DESCRIPTION
## Summary
- add `tests/` with pytest based unit tests using stubs
- provide fixture to mock external langchain dependencies
- include instructions for running `pytest` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c205ac5488323a9d7c23e02028cfe