### PR TITLE
Make document URL configurable

### DIFF
--- a/rag_chatbot/main.py
+++ b/rag_chatbot/main.py
@@ -1,19 +1,24 @@
 import os
+import argparse
 from dotenv import load_dotenv
 from src.document_loader import load_documents
 from src.text_splitter import split_documents
 from src.vector_store import create_vector_store
 from src.rag_pipeline import initialize_rag_components, create_rag_graph
+from src.config import DOC_URL
 
-def main():
+def main(doc_url: str | None = None):
     # Carrega as variáveis de ambiente do arquivo .env
     load_dotenv(dotenv_path='rag_chatbot/.env')
 
     print("Iniciando o processo de indexação de documentos...")
 
     # 1. Carregar documentos
+    if doc_url is None:
+        doc_url = DOC_URL
+
     print("Carregando documentos da URL...")
-    documents = load_documents()
+    documents = load_documents(doc_url)
     print(f"Total de documentos carregados: {len(documents)}")
 
     if not documents:
@@ -68,4 +73,8 @@ def main():
     print(final_state["answer"])
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Indexa documentos para o RAG.")
+    parser.add_argument("--url", help="URL dos documentos", default=None)
+    args = parser.parse_args()
+
+    main(doc_url=args.url)

--- a/rag_chatbot/src/config.py
+++ b/rag_chatbot/src/config.py
@@ -1,0 +1,8 @@
+import os
+from dotenv import load_dotenv
+
+# Carrega variáveis de ambiente do arquivo .env localizado em rag_chatbot/
+load_dotenv(dotenv_path='rag_chatbot/.env')
+
+# URL padrão do documento para indexação
+DOC_URL = os.getenv('DOC_URL', 'https://lilianweng.github.io/posts/2023-06-23-agent/')

--- a/rag_chatbot/src/document_loader.py
+++ b/rag_chatbot/src/document_loader.py
@@ -1,10 +1,14 @@
 from langchain_community.document_loaders import WebBaseLoader
 from bs4 import BeautifulSoup, SoupStrainer
+from rag_chatbot.src.config import DOC_URL
 
-def load_documents(url: str = "https://lilianweng.github.io/posts/2023-06-23-agent/"):
+def load_documents(url: str | None = None):
     """
     Carrega documentos de uma URL usando WebBaseLoader e BeautifulSoup.
     """
+    if url is None:
+        url = DOC_URL
+
     loader = WebBaseLoader(
         web_path=url,
         bs_kwargs=dict(
@@ -16,7 +20,13 @@ def load_documents(url: str = "https://lilianweng.github.io/posts/2023-06-23-age
     return loader.load()
 
 if __name__ == "__main__":
-    docs = load_documents()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Carrega documentos de uma URL")
+    parser.add_argument("--url", help="URL dos documentos", default=None)
+    args = parser.parse_args()
+
+    docs = load_documents(args.url)
     print(f"Documentos carregados: {len(docs)}")
     if docs:
         print(f"Conteúdo do primeiro documento (parcial): {docs[0].page_content[:500]}...")

--- a/rag_chatbot/src/rag_pipeline.py
+++ b/rag_chatbot/src/rag_pipeline.py
@@ -51,14 +51,14 @@ class GraphState(TypedDict):
 # Removendo a necessidade de importá-los diretamente de rag_pipeline em outros módulos.
 # Eles serão passados como argumentos ou obtidos do retorno de initialize_rag_components.
 
-def initialize_rag_components():
+def initialize_rag_components(doc_url: str | None = None):
     """
     Inicializa e retorna os componentes RAG (LLM, Prompt, Vector Store, Retriever, Structured LLM).
     """
     print("Inicializando componentes RAG...")
     
     # Carregar e dividir documentos para o vector store
-    documents = load_documents()
+    documents = load_documents(doc_url)
     chunks = split_documents(documents)
     vector_store = create_vector_store(chunks)
     
@@ -163,8 +163,14 @@ def create_rag_graph(vector_store, llm, rag_prompt, structured_llm):
     return app
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Testa o pipeline RAG.")
+    parser.add_argument("--url", help="URL dos documentos", default=None)
+    args = parser.parse_args()
+
     # Inicializar componentes RAG antes de criar e usar o grafo
-    components = initialize_rag_components()
+    components = initialize_rag_components(args.url)
     vector_store = components["vector_store"]
     llm = components["llm"]
     rag_prompt = components["rag_prompt"]


### PR DESCRIPTION
## Summary
- add `config.py` with `DOC_URL` loaded from environment
- make `load_documents` use `DOC_URL` by default
- allow `main.py`, `rag_pipeline.py`, and `document_loader.py` to accept `--url`
- wire optional URL into `initialize_rag_components`

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_684c2065d304832394ff1bfd1bfbb74c