### PR TITLE
Add MessagesState-based RAG flow

### DIFF
--- a/rag_chatbot/requirements.txt
+++ b/rag_chatbot/requirements.txt
@@ -2,6 +2,7 @@ langchain-text-splitters
 langchain-community
 langgraph
 langchain-google-genai
+langchain-core
 beautifulsoup4
 chromadb
 streamlit

--- a/rag_chatbot/src/streamlit_app.py
+++ b/rag_chatbot/src/streamlit_app.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 # Importar funções e componentes do pipeline RAG
-from src.rag_pipeline import initialize_rag_components, create_rag_graph, GraphState
+from src.rag_pipeline import initialize_rag_components, create_rag_graph
 from src.advanced_features import stream_rag_response # Importar a função de streaming
 
 # Carrega as variáveis de ambiente do arquivo .env

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,20 +4,29 @@ from types import SimpleNamespace
 def test_rag_pipeline(monkeypatch):
     pipeline = importlib.import_module('rag_chatbot.src.rag_pipeline')
 
+    HumanMessage = importlib.import_module('langchain_core.messages').HumanMessage
+    AIMessage = importlib.import_module('langchain_core.messages').AIMessage
+    ToolMessage = importlib.import_module('langchain_core.messages').ToolMessage
+
     def dummy_analyze(state, structured_llm=None):
-        return {"question": state["question"], "query": {"query": "q", "section": "beginning"}}
+        msgs = state["messages"]
+        ai = AIMessage(content="", additional_kwargs={"tool_calls": [{"id": "1", "args": {"query": "q", "section": "beginning"}}]})
+        return {"messages": msgs + [ai]}
 
     def dummy_retrieve(state, vector_store=None):
+        msgs = state["messages"]
         doc = SimpleNamespace(page_content="ctx", metadata={"section": "beginning"})
-        return {"question": state["question"], "query": state["query"], "context": [doc]}
+        tool = ToolMessage(content="", tool_call_id="1", additional_kwargs={"documents": [doc]})
+        return {"messages": msgs + [tool]}
 
     def dummy_generate(state, llm=None, rag_prompt=None):
-        return {"question": state["question"], "context": state["context"], "answer": "ans"}
+        msgs = state["messages"]
+        return {"messages": msgs + [AIMessage(content="ans")]} 
 
     monkeypatch.setattr(pipeline, 'analyze_query', dummy_analyze)
     monkeypatch.setattr(pipeline, 'retrieve', dummy_retrieve)
     monkeypatch.setattr(pipeline, 'generate', dummy_generate)
 
     graph = pipeline.create_rag_graph(None, None, None, None)
-    result = graph.invoke({"question": "hi"})
-    assert result["answer"] == "ans"
+    result = graph.invoke({"messages": [HumanMessage(content="hi")]})
+    assert result["messages"][-1].content == "ans"


### PR DESCRIPTION
## Summary
- refactor rag_pipeline to use `MessagesState` and chat messages
- update streamlit import after removing `GraphState`
- add `langchain-core` to requirements
- extend stubs and pipeline tests for message-based flow

## Testing
- `pytest -q`
- `python rag_chatbot/main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684c31ec2db08323b8034c0fd21b3a5c