### PR TITLE
Add tool-calling retrieval and chat nodes

### DIFF
--- a/rag_chatbot/src/chat_nodes.py
+++ b/rag_chatbot/src/chat_nodes.py
@@ -1,0 +1,31 @@
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+from langgraph.prebuilt import ToolNode
+from langgraph.graph import MessagesState
+
+from .vector_store import retrieve
+
+
+def query_or_respond(state: MessagesState, llm):
+    model = llm.bind_tools([retrieve])
+    response = model.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+tool_node = ToolNode([retrieve])
+
+def tools(state: MessagesState):
+    return tool_node.invoke(state)
+
+
+def generate(state: MessagesState, llm, prompt):
+    messages = state["messages"]
+    docs = []
+    if messages and isinstance(messages[-1], ToolMessage):
+        docs = messages[-1].additional_kwargs.get("docs", [])
+    question = next((m.content for m in messages if isinstance(m, HumanMessage)), "")
+    context = "\n\n".join(d.page_content for d in docs)
+    formatted = prompt.format_messages(context=context, question=question)
+    answer = llm.invoke(formatted)
+    return {"messages": [AIMessage(content=answer)]}

--- a/rag_chatbot/src/vector_store.py
+++ b/rag_chatbot/src/vector_store.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langchain_community.vectorstores import Chroma
 from langchain_core.documents import Document
+from langchain_core.tools import tool
 from .advanced_features import CachedEmbeddings
 import logging
 from .logging_config import setup_logging
@@ -47,6 +48,23 @@ def add_documents_to_vector_store(vector_store: Chroma, documents: list[Document
     """
     vector_store.add_documents(documents)
     logger.info(f"Adicionados {len(documents)} documentos ao vector store.")
+
+vector_store: Chroma | None = None
+
+
+@tool(response_format="content_and_artifact")
+def retrieve(query: str):
+    """Retrieve information related to a query."""
+    if vector_store is None:
+        return "", []
+    retrieved_docs = vector_store.similarity_search(query, k=2)
+    serialized = "\n\n".join(
+        (
+            f"Source: {doc.metadata}\n" f"Content: {doc.page_content}"
+            for doc in retrieved_docs
+        )
+    )
+    return serialized, retrieved_docs
 
 if __name__ == "__main__":
     # Exemplo de uso (normalmente seria chamado por outro módulo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,25 @@ def stub_libraries(monkeypatch):
     graph_module.END = "end"
     monkeypatch.setitem(sys.modules, "langgraph.graph", graph_module)
 
+    # langgraph.prebuilt
+    prebuilt_module = types.ModuleType("langgraph.prebuilt")
+    class DummyToolNode:
+        def __init__(self, tools):
+            self.tools = tools
+        def invoke(self, state):
+            return state
+    prebuilt_module.ToolNode = DummyToolNode
+    monkeypatch.setitem(sys.modules, "langgraph.prebuilt", prebuilt_module)
+
+    # langchain_core.tools
+    tools_module = types.ModuleType("langchain_core.tools")
+    def tool(*args, **kwargs):
+        def decorator(fn):
+            return fn
+        return decorator
+    tools_module.tool = tool
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_module)
+
     # Ensure GOOGLE_API_KEY exists so get_embeddings_model doesn't fail
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
 

--- a/tests/test_chat_nodes.py
+++ b/tests/test_chat_nodes.py
@@ -1,0 +1,24 @@
+import importlib
+from types import SimpleNamespace
+
+
+def test_chat_nodes_flow(monkeypatch):
+    chat_nodes = importlib.import_module('rag_chatbot.src.chat_nodes')
+    msgs = importlib.import_module('langchain_core.messages')
+
+    # stub llm
+    def bind_tools(tools):
+        def invoke(messages):
+            return msgs.AIMessage(content="", additional_kwargs={"tool_calls": [{"id": "1", "name": "retrieve", "args": {"query": "hello"}}]})
+        return SimpleNamespace(invoke=invoke)
+    llm = SimpleNamespace(bind_tools=bind_tools, invoke=lambda x: "final")
+
+    state = {"messages": [msgs.HumanMessage(content="Hello")]}
+    state1 = chat_nodes.query_or_respond(state, llm)
+    assert state1["messages"]
+
+    state2 = chat_nodes.tools(state1)
+    assert "messages" in state2
+
+    final = chat_nodes.generate(state2, llm, SimpleNamespace(format_messages=lambda **k: "prompt"))
+    assert final["messages"][0].content == "final"


### PR DESCRIPTION
## Summary
- add `retrieve` tool to `vector_store`
- implement chat node helpers for tool-calling
- stub `langchain_core.tools` and `langgraph.prebuilt` for tests
- cover chat node flow with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c34be90688323abc54197f1fff16a